### PR TITLE
perf: avoid useless function call

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -547,12 +547,8 @@ module.exports = class Response extends Writable {
         }
         return this;
     }
-    header(field, value) {
-        return this.set(field, value);
-    }
-    setHeader(field, value) {
-        return this.set(field, value);
-    }
+    header = this.set;
+    setHeader = this.set;
     get(field) {
         return this.headers[field.toLowerCase()];
     }


### PR DESCRIPTION
Just a little performance improvements: direct call final function instead of wrapper